### PR TITLE
Added support for Python 3.8 and Apps APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,8 @@ dmypy.json
 # Alex Folder.
 vscode/
 config/
+.config/
+api_setup.py
+logs/
+.vscode/
+.github/

--- a/powerbi/apps.py
+++ b/powerbi/apps.py
@@ -1,0 +1,212 @@
+from typing import Dict
+from powerbi.session import PowerBiSession
+
+
+class Apps():
+
+    def __init__(self, session: object) -> None:
+        """Initializes the `Apps` service.
+
+        ### Parameters
+        ----
+        session : object
+            An authenticated session for our Microsoft PowerBi Client.
+
+        ### Usage
+        ----
+            >>> apps_service = power_bi_client.apps()
+        """
+
+        # Set the session.
+        self.power_bi_session: PowerBiSession = session
+
+        # Set the endpoint.
+        self.endpoint = 'myorg/apps'
+    
+    def get_app(self, app_id: str) -> Dict:
+        """Returns the specified installed app.
+
+        ### Returns
+        -------
+        Dict
+            A collection of `App` resources.
+
+        ### Usage
+        ----
+            >>> apps_service = power_bi_client.apps()
+            >>> apps_service.get_app(app_id='c0g14be3-38d3-49hc-ef1d-b4f57c9c9058')
+        """
+
+        content = self.power_bi_session.make_request(
+            method='get',
+            endpoint=f'myorg/apps/{app_id}'
+        )
+
+        return content
+
+
+    def get_apps(self) -> Dict:
+        """Returns a list of installed apps.
+
+        ### Returns
+        -------
+        Dict
+            A collection of `Apps` resources.
+
+        ### Usage
+        ----
+            >>> apps_service = power_bi_client.apps()
+            >>> apps_service.get_apps()
+        """
+
+        content = self.power_bi_session.make_request(
+            method='get',
+            endpoint=self.endpoint
+        )
+
+        return content
+
+    def get_dashboard(self, app_id: str, dashboard_id: str) -> Dict:
+        """Returns the specified dashboard from the specified app.
+
+        ### Returns
+        -------
+        Dict
+            A collection of `Dashboard` resources.
+
+        ### Usage
+        ----
+            >>> apps_service = power_bi_client.apps()
+            >>> apps_service.get_dashboard(
+                app_id='c0g14be3-38d3-49hc-ef1d-b4f57c9c9058',
+                dashboard_id='088bbddg-a162-4a31-98f8-1aea79df954a'
+                )
+        """
+
+        content = self.power_bi_session.make_request(
+            method='get',
+            endpoint=f'myorg/apps/{app_id}/dashboards/{dashboard_id}'
+        )
+
+        return content
+
+    def get_dashboards(self, app_id: str) -> Dict:
+        """Returns a list of dashboards from the specified app.
+
+        ### Returns
+        -------
+        Dict
+            A collection of `Dashboards` resources.
+
+        ### Usage
+        ----
+            >>> apps_service = power_bi_client.apps()
+            >>> apps_service.get_dashboards(
+                app_id='f089354e-8366-4e18-aea3-4cb4a3a50b48'
+                )
+        """
+
+        content = self.power_bi_session.make_request(
+            method='get',
+            endpoint=f'myorg/apps/{app_id}/dashboards'
+        )
+
+        return content
+
+    def get_report(self, app_id: str, report_id: str) -> Dict:
+        """Returns the specified report from the specified app.
+
+        ### Returns
+        -------
+        Dict
+            A collection of `Report` resources.
+
+        ### Usage
+        ----
+            >>> apps_service = power_bi_client.apps()
+            >>> apps_service.get_report(
+                app_id='f089354e-8366-4e18-aea3-4cb4a3a50b48',
+                report_id='088bbddg-a162-4a31-98f8-1aea79df954a'
+                )
+        """
+
+        content = self.power_bi_session.make_request(
+            method='get',
+            endpoint=f'myorg/apps/{app_id}/reports/{report_id}'
+        )
+
+        return content
+
+    def get_reports(self, app_id: str) -> Dict:
+        """Returns a list of reports from the specified app.
+
+        ### Returns
+        -------
+        Dict
+            A collection of `Reports` resources.
+
+        ### Usage
+        ----
+            >>> apps_service = power_bi_client.apps()
+            >>> apps_service.get_reports(
+                app_id='f089354e-8366-4e18-aea3-4cb4a3a50b48'
+                )
+        """
+
+        content = self.power_bi_session.make_request(
+            method='get',
+            endpoint=f'myorg/apps/{app_id}/reports'
+        )
+
+        return content
+
+    def get_tile(self, app_id: str, dashboard_id: str, tile_id: str) -> Dict:
+        """Returns the specified tile within the specified dashboard from the specified app.
+        
+        Supported tiles include datasets and live tiles that contain an entire report page.
+
+        ### Returns
+        -------
+        Dict
+            A collection of `Tile` resources.
+
+        ### Usage
+        ----
+            >>> apps_service = power_bi_client.apps()
+            >>> apps_service.get_tile(
+                app_id='f089354e-8366-4e18-aea3-4cb4a3a50b48',
+                dashboard_id='5b218778-e7a5-4d73-8187-f10824047715',
+                tile_id='312fbfe9-2eda-44e0-9ed0-ab5dc571bb4b'
+                )
+        """
+
+        content = self.power_bi_session.make_request(
+            method='get',
+            endpoint=f'myorg/apps/{app_id}/dashboards/{dashboard_id}/tiles/{tile_id}'
+        )
+
+        return content
+
+    def get_tiles(self, app_id: str, dashboard_id: str) -> Dict:
+        """Returns a list of reports from the specified app.
+
+        ### Returns
+        -------
+        Dict
+            A collection of `Tiles` resources.
+
+        ### Usage
+        ----
+            >>> apps_service = power_bi_client.apps()
+            >>> apps_service.get_tiles(
+                app_id='f089354e-8366-4e18-aea3-4cb4a3a50b48',
+                dashboard_id='5b218778-e7a5-4d73-8187-f10824047715'
+                )
+        """
+
+        content = self.power_bi_session.make_request(
+            method='get',
+            endpoint=f'myorg/apps/{app_id}/dashboards/{dashboard_id}/tiles'
+        )
+
+        return content

--- a/powerbi/client.py
+++ b/powerbi/client.py
@@ -13,6 +13,7 @@ from powerbi.imports import Imports
 from powerbi.reports import Reports
 from powerbi.available_features import AvailableFeatures
 from powerbi.capacities import Capacities
+from powerbi.apps import Apps
 
 
 class PowerBiClient():
@@ -85,6 +86,31 @@ class PowerBiClient():
         self.power_bi_session = PowerBiSession(
             client=self.power_bi_auth_client
         )
+
+    def apps(self) -> Apps:
+        """Used to access the `Apps` Services and metadata.
+
+        ### Returns
+        ---
+        Apps :
+            The `Apps` services Object.
+
+        ### Usage
+        ----
+            >>> power_bi_client = PowerBiClient(
+                client_id=client_id,
+                client_secret=client_secret,
+                scope=['https://analysis.windows.net/powerbi/api/.default'],
+                redirect_uri=redirect_uri,
+                credentials='config/power_bi_state.jsonc'
+            )
+            >>> apps_service = power_bi_client.apps()
+        """
+
+        # Grab the Groups Object for the session.
+        object = Apps(session=self.power_bi_session)
+
+        return object
 
     def dashboards(self) -> Dashboards:
         """Used to access the `Dashboards` Services and metadata.

--- a/powerbi/session.py
+++ b/powerbi/session.py
@@ -2,6 +2,7 @@ import json
 import requests
 import logging
 import pathlib
+import sys
 
 from typing import Dict
 
@@ -40,13 +41,19 @@ class PowerBiSession():
         if not pathlib.Path('logs').exists():
             pathlib.Path('logs').mkdir()
             pathlib.Path('logs/log_file_custom.log').touch()
-
-        logging.basicConfig(
-            filename="logs/log_file_custom.log",
-            level=logging.INFO,
-            encoding="utf-8",
-            format=log_format
-        )
+        if sys.version_info[1]==8:
+            logging.basicConfig(
+                filename="logs/log_file_custom.log",
+                level=logging.INFO,
+                format=log_format
+            )
+        else:
+            logging.basicConfig(
+                filename="logs/log_file_custom.log",
+                level=logging.INFO,
+                encoding="utf-8",
+                format=log_format
+            )
 
     def build_headers(self) -> Dict:
         """Used to build the headers needed to make the request.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,6 +15,7 @@ from powerbi.push_datasets import PushDatasets
 from powerbi.available_features import AvailableFeatures
 from powerbi.capacities import Capacities
 from powerbi.reports import Reports
+from powerbi.apps import Apps
 
 
 class TestPowerBiSession(TestCase):
@@ -63,6 +64,14 @@ class TestPowerBiSession(TestCase):
         self.assertIsInstance(
             self.power_bi_client.power_bi_auth_client,
             PowerBiAuth
+        )
+
+    def test_creates_instance_of_apps(self):
+        """Create an instance and make sure it's a `Apps` object"""
+
+        self.assertIsInstance(
+            self.power_bi_client.apps(),
+            Apps
         )
 
     def test_creates_instance_of_dashboards(self):


### PR DESCRIPTION
Hi Alex! I've been playing around with this package and wanted some of the functionality found in the Apps part of the PowerBI REST API, so I went ahead and created a whole module for it. I also was running into issues with the logging package that comes with my Python 3.8.x install due to the logging.basicConfig() taking an argument _encoding_ that doesn't exist in the 3.8.x version of the logging package (although weirdly it reappears for 3.9+).